### PR TITLE
Fixed warning in NoteView.m

### DIFF
--- a/Classes/NoteView.m
+++ b/Classes/NoteView.m
@@ -42,7 +42,7 @@
     CGFloat baselineOffset = 6.0f;
 	
     //iterate over numberOfLines and draw each line
-    for (int x = 1; x < numberOfLines; x++) {
+    for (NSUInteger x = 1; x < numberOfLines; x++) {
         
         //0.5f offset lines up line with pixel boundary
         CGContextMoveToPoint(context, self.bounds.origin.x+10, self.font.leading*x + 0.5f + baselineOffset);


### PR DESCRIPTION
In NoteView's drawRect: method the for-loop's condition compares an NSUInteger with an int which causes a compiler warning.

Fixed it by changing the int to NSUInteger.
